### PR TITLE
exclude QCFAIL reads from duplicate detection as in bammarkduplicates

### DIFF
--- a/src/programs/bammarkduplicates2.cpp
+++ b/src/programs/bammarkduplicates2.cpp
@@ -1268,7 +1268,8 @@ static int markDuplicates(::libmaus::util::ArgInfo const & arginfo)
 
 	uint64_t const colexcludeflags =
 		libmaus::bambam::BamFlagBase::LIBMAUS_BAMBAM_FSECONDARY |
-		libmaus::bambam::BamFlagBase::LIBMAUS_BAMBAM_FSUPPLEMENTARY;
+		libmaus::bambam::BamFlagBase::LIBMAUS_BAMBAM_FSUPPLEMENTARY |
+		libmaus::bambam::BamFlagBase::LIBMAUS_BAMBAM_FQCFAIL;
 	
 	if ( arginfo.getPairCount("I") > 1 )
 	{


### PR DESCRIPTION
to fix possible accidental omission in commit 3a2bfb9e3037e7f1ff7a31c3c0f027113aea489d
